### PR TITLE
Implement basic subpath pattern support

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -53,10 +53,21 @@ function validateValue(relative, dir, entry, value, type) {
 			`File paths must be relative and start with a dot. Got "${value}" instead`,
 		);
 	} else if (!fs.existsSync(path.join(dir, value))) {
-		error(
-			relative,
-			`File not found for "${entry}" ${type ? type + ": " : ""}${value}`,
-		);
+		if (entry.indexOf("*") !== -1 && value.indexOf("*") !== -1) {
+        	const subPath = value.substr(0, value.indexOf("*"));
+
+             if (!fs.existsSync(path.join(dir, subPath.substr(0, subPath.lastIndexOf("/") + 1)))) {
+             	error(
+					relative,
+					`Invalid subpath for "${entry}" ${type ? type + ": " : ""}${value}`
+				);
+        	}
+		} else {
+			error(
+				relative,
+				`File not found for "${entry}" ${type ? type + ": " : ""}${value}`
+			);
+		}
 	}
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -54,14 +54,14 @@ function validateValue(relative, dir, entry, value, type) {
 		);
 	} else if (!fs.existsSync(path.join(dir, value))) {
 		if (entry.indexOf("*") !== -1 && value.indexOf("*") !== -1) {
-        	const subPath = value.substr(0, value.indexOf("*"));
+        		const subPath = value.substr(0, value.indexOf("*"));
 
-             if (!fs.existsSync(path.join(dir, subPath.substr(0, subPath.lastIndexOf("/") + 1)))) {
-             	error(
+             		if (!fs.existsSync(path.join(dir, subPath.substr(0, subPath.lastIndexOf("/") + 1)))) {
+             			error(
 					relative,
 					`Invalid subpath for "${entry}" ${type ? type + ": " : ""}${value}`
 				);
-        	}
+        		}
 		} else {
 			error(
 				relative,


### PR DESCRIPTION
Hi there!

First of all, thank you for creating this package! Very useful for the validation of the export map.

May I make the following PR: I use the subpath pattern (as described here https://nodejs.org/api/packages.html#packages_subpath_patterns) and this PR implements basic support for this. For now, it's nothing fancy and just a basic test. It detects the use of a wildcard and - if present - then finds the parent path of that subpath and check if it exists.

Small change and feel free to merge it.

Thanks and keep up the good work!

Kind regards,

Mark